### PR TITLE
Include header: functional

### DIFF
--- a/callback_swapchain.h
+++ b/callback_swapchain.h
@@ -20,6 +20,7 @@
 #include "layer.h"
 #include <atomic>
 #include <deque>
+#include <functional>
 #include <mutex>
 #include <vulkan/vulkan.h>
 


### PR DESCRIPTION
It seems that on my current Linux machine, this is necessary. At least it looks more correct, since we do use `std::function` here.