### PR TITLE
Fix call to vkGetDeviceQueue

### DIFF
--- a/layer.cpp
+++ b/layer.cpp
@@ -273,11 +273,11 @@ vkCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
   {
     auto queue_map = GetGlobalContext().GetQueueMap();
     for (size_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
+      auto queue_family_index = pCreateInfo->pQueueCreateInfos[i].queueFamilyIndex;
       for (size_t j = 0; j < pCreateInfo->pQueueCreateInfos[i].queueCount;
            ++j) {
         VkQueue q;
-        data.vkGetDeviceQueue(
-            *pDevice, pCreateInfo->pQueueCreateInfos[i].queueCount, j, &q);
+        data.vkGetDeviceQueue(*pDevice, queue_family_index, j, &q);
         (*queue_map)[q] = {*pDevice, data.vkQueueSubmit};
       }
     }


### PR DESCRIPTION
The call to vkGetDeviceQueue was using the `queueCount` instead of the expected `queueFamilyIndex` from the create info struct. The call doesn't fail, but returns a `nil` queue. This `nil` in the map would then result in some subsequent queue submit crashing the application using this layer (in my case it was vulkan_test_applications).