### PR TITLE
Intercept the vkCreateStreamDescriptorSurfaceGGP command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ vkQueuePresentKHR
 vkDestroySurfaceKHR
 vkCreateAndroidSurfaceKHR
 vkCreateMirSurfaceKHR
+vkCreateStreamDescriptorSurfaceGGP
 vkCreateWaylandSurfaceKHR
 vkCreateWin32SurfaceKHR
 vkCreateXcbSurfaceKHR

--- a/layer.cpp
+++ b/layer.cpp
@@ -473,6 +473,7 @@ vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
   // Intercept all of the surface creation routines for all platforms.
   INTERCEPT_SURFACE(vkCreateAndroidSurfaceKHR);
   INTERCEPT_SURFACE(vkCreateMirSurfaceKHR);
+  INTERCEPT_SURFACE(vkCreateStreamDescriptorSurfaceGGP);
   INTERCEPT_SURFACE(vkCreateWaylandSurfaceKHR);
   INTERCEPT_SURFACE(vkCreateWin32SurfaceKHR);
   INTERCEPT_SURFACE(vkCreateXcbSurfaceKHR);


### PR DESCRIPTION
This is a part of the
[`VK_GGP_stream_descriptor_surface`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_GGP_stream_descriptor_surface.html)
extension.